### PR TITLE
Change fmt.Printf to log.Printf

### DIFF
--- a/geoelevations/utils.go
+++ b/geoelevations/utils.go
@@ -54,7 +54,7 @@ func unzipBytes(byts []byte) ([]byte, error) {
 	// Iterate through the files in the archive,
 	// printing some of their contents.
 	for _, f := range r.File {
-		fmt.Printf("Contents of %s:\n", f.Name)
+		log.Printf("Contents of %s:\n", f.Name)
 		rc, err := f.Open()
 		if err != nil {
 			log.Printf("Error reading %s: %s", f.Name, err.Error())


### PR DESCRIPTION
I'm trying to disable output, which is possible with `log.SetOutput(ioutil.Discard)`... however this message is still displayed.